### PR TITLE
Replace deprecated `lazy_static` with once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,7 +1919,6 @@ dependencies = [
  "futures",
  "http 0.2.9",
  "jsonwebtoken",
- "lazy_static",
  "mime",
  "once_cell",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ jsonwebtoken = "8.3.0"
 once_cell = "1.19.0"
 bcrypt = "0.15.1"
 validator = { version = "0.18.1", features = ["derive"] }
-lazy_static = "1.4.0"
 mime = "0.3.17"
 bytes = "1.6.0"
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,11 +1,11 @@
 use config::{Config, ConfigError, Environment, File};
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use serde::Deserialize;
 use std::{env, fmt};
 
-lazy_static! {
-  pub static ref SETTINGS: Settings = Settings::new().expect("Failed to setup settings");
-}
+pub static SETTINGS: Lazy<Settings> = Lazy::new(|| {
+  Settings::new().expect("Failed to setup settings")
+});
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Server {

--- a/src/tests/setup.rs
+++ b/src/tests/setup.rs
@@ -1,5 +1,5 @@
 use bson::doc;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use std::net::SocketAddr;
 use tokio::runtime::Runtime;
 use tokio::sync::OnceCell;
@@ -11,6 +11,7 @@ use crate::settings::SETTINGS;
 use crate::utils::models::ModelExt;
 
 static API: OnceCell<()> = OnceCell::const_new();
+static RUNTIME: Lazy<Runtime> = Lazy::new(|| Runtime::new().unwrap());
 
 pub async fn start_api_once() {
   API
@@ -29,10 +30,6 @@ pub async fn start_api_once() {
       });
     })
     .await;
-}
-
-lazy_static! {
-  static ref RUNTIME: Runtime = Runtime::new().unwrap();
 }
 
 pub fn use_app<F>(test: F)


### PR DESCRIPTION
Closes #418 

This PR replaces all uses of the deprecated `lazy_static` in favor of `once_cell` for initializing global state. 